### PR TITLE
Failure states

### DIFF
--- a/bin/debci-generate-index
+++ b/bin/debci-generate-index
@@ -265,6 +265,24 @@ generate_package_blame() {
   fi
 }
 
+# this reads all previous result json files, but should only run
+# once for each package, after which the last_pass_version is cached
+# in each successive json and copied forwards
+find_last_pass_version() {
+  last_pass_version="never"
+  last_pass_date="never"
+  result_json=$(find "${status_dir}" -name '*.json' \
+                -and -not -name latest.json \
+                -and -not -name history.json \
+                | sort -V)
+  for f in ${result_json}; do
+    if [ $(jq -r .status ${f}) = 'pass' ]; then
+      last_pass_version="$(jq -r .version ${f})"
+      last_pass_date="$(jq -r .date ${f})"
+    fi
+  done
+}
+
 # arguments: <timestamp>
 generate_package_json() {
   local timestamp="$1"
@@ -277,6 +295,22 @@ generate_package_json() {
   local previous_status="${last_status}"
   if [ "${previous_status}" = 'tmpfail' ]; then
     previous_status=$(debci-status --field previous_status "$pkg")
+  fi
+
+  # record the last version and date for which the test passed,
+  # to distinguish between packages which have never passed, never
+  # passed for the current version, or failed recently
+  local last_pass_version=""
+  local last_pass_date=""
+
+  if [ "${status}" = 'pass' ]; then
+    last_pass_version="${version}"
+    last_pass_date="${timestamp}"
+  elif [ $(debci-status --field last_pass_version "$pkg") != 'unknown' ]; then
+    last_pass_version="$(jq -r .last_pass_version ${status_dir}/latest.json)"
+    last_pass_date="$(jq -r .last_pass_date ${status_dir}/latest.json)"
+  else
+    find_last_pass_version
   fi
 
   if [ -n "$artifacts_url_base" ]; then
@@ -298,7 +332,9 @@ generate_package_json() {
   "previous_status": "${previous_status}",
   "duration_seconds": "${duration}",
   "duration_human": "${duration_human}",
-  "message": "${message}"${extra_fields}
+  "message": "${message}",
+  "last_pass_version": "${last_pass_version}",
+  "last_pass_date": "${last_pass_date}"${extra_fields}
 }
 EOF
 

--- a/debian/control
+++ b/debian/control
@@ -36,6 +36,7 @@ Depends: adduser,
          patchutils,
          ruby,
          sudo,
+         jq,
          ${misc:Depends},
          ${shlibs:Depends}
 Recommends: apt-cacher-ng,

--- a/lib/debci/html.rb
+++ b/lib/debci/html.rb
@@ -75,6 +75,7 @@ module Debci
       @site_url = expand_url(Debci.config.url_base, @suite)
       @artifacts_url_base = expand_url(Debci.config.artifacts_url_base, @suite)
       @moretitle = "#{package.name}/#{suite}/#{architecture}"
+      @latest = package.history(@suite, @architecture).first
       expand_template(:history, filename)
     end
 

--- a/lib/debci/html/history.erb
+++ b/lib/debci/html/history.erb
@@ -29,6 +29,12 @@
         </div>
       <% end %>
 
+      <% if @latest && @latest.status == :fail %>
+        <div class='alert alert-warning <%= @latest.extended_status %>'>
+          This package is failing and has <%= @latest.failmsg %>.
+        </div>
+      <% end %>
+
       <table class="table">
         <tr>
           <td><b>Version</b></td>

--- a/lib/debci/html/index.erb
+++ b/lib/debci/html/index.erb
@@ -15,7 +15,7 @@
         <% else %>
           <% news.each do |item| %>
             <a href="/packages/<%= @repository.find_package(item.package).prefix %>/<%= item.package %>/<%= item.suite %>/<%= item.architecture %>"
-              class="list-group-item <%= item.status %>"><%= item.headline %><div><small class="text-muted"><%= item.date %> | <strong><%= item.time %></strong></small></div></a>
+              class="list-group-item <%= item.extended_status %>"><%= item.headline %><div><small class="text-muted"><%= item.date %> | <strong><%= item.time %></strong></small></div></a>
           <% end %>
         <% end %>
 

--- a/lib/debci/html/package.erb
+++ b/lib/debci/html/package.erb
@@ -48,7 +48,7 @@
 
             <% row.each do |status| %>
               <% if status.status.eql?(:no_test_data) %>
-                  <td class="<%= status.status %>"><%= status.title %></td>
+                  <td class="<%= status.extended_status %>"><%= status.title %></td>
               <% else %>
                   <% package_dir = "/packages/#{@package.prefix}" +
                                    "/#{@package.name}/#{status.suite}" +

--- a/lib/debci/html/packagelist.erb
+++ b/lib/debci/html/packagelist.erb
@@ -32,8 +32,8 @@
               <% if package.failures.any? %>
                 <td>
                   <% package.failures.each do |s| %>
-                    <a class='fail' href='<%= "/packages/#{@prefix}/#{package.name}/#{s.suite}/#{s.architecture}"%>'>
-                      <%= s.version %> <%= s.status.upcase %> <%= s.suite %>/<%= s.architecture %>
+                    <a class='<%= s.extended_status %>' href='<%= "/packages/#{@prefix}/#{package.name}/#{s.suite}/#{s.architecture}"%>'>
+                      <%= s.version %> <%= s.status.upcase %> <%= s.suite %>/<%= s.architecture %> (<%= s.failmsg %>)
                     </a>
                   <% end %>
                 </td>

--- a/lib/debci/html/platform_specific_issues.erb
+++ b/lib/debci/html/platform_specific_issues.erb
@@ -13,7 +13,7 @@
             <td><%= package %></td>
             <td>
               <% statuses.each do |status| %>
-                <a  class='<%= status.status %>'
+                <a  class='<%= status.extended_status %>'
                     href="/packages/<%= Debci::Package.new(package).prefix %>/<%= package %>/<%= status.suite %>/<%= status.architecture %>/">
                   <%= status.suite %>/<%= status.architecture%> <%= status.status %> (<%= status.duration_human %>)
                 </a>

--- a/lib/debci/status.rb
+++ b/lib/debci/status.rb
@@ -8,7 +8,7 @@ module Debci
   class Status
 
     attr_reader :blame
-    attr_accessor :suite, :architecture, :run_id, :package, :version, :date, :status, :previous_status, :duration_seconds, :duration_human, :message
+    attr_accessor :suite, :architecture, :run_id, :package, :version, :date, :status, :previous_status, :duration_seconds, :duration_human, :message, :last_pass_version, :last_pass_date
 
     # Returns `true` if this status object represents an important event, such
     # as a package that used to pass started failing, of vice versa.
@@ -110,6 +110,13 @@ module Debci
         end
       status.duration_human = data['duration_human']
       status.message = data['message']
+      status.last_pass_version = data.fetch('last_pass_version', 'unknown')
+      status.last_pass_date =
+        begin
+          Time.parse(data.fetch('last_pass_date', 'unknown') + ' UTC')
+        rescue ArgumentError
+          nil
+        end
 
       status
     end

--- a/lib/debci/status.rb
+++ b/lib/debci/status.rb
@@ -79,12 +79,25 @@ module Debci
     # Returns a headline for this status object, to be used as a short
     # description of the event it represents
     def headline
-      "#{package} #{version} #{status.upcase}ED on #{suite}/#{architecture}"
+      msg = "#{package} #{version} #{status.upcase}ED on #{suite}/#{architecture}"
+      if status == :fail
+        msg += " (#{failmsg})"
+      end
+      msg
     end
 
     # A longer version of the headline
+    # for a new failure, include whether this version previously passed
     def description
-      "The tests for #{package}, version #{version}, #{status.upcase}ED on #{suite}/#{architecture} but have previously #{previous_status.upcase}ED."
+      msg = "The tests for #{package}, version #{version}, #{status.upcase}ED on #{suite}/#{architecture} but have previously #{previous_status.upcase}ED"
+      msg += case extended_status
+        when :fail_passed_current
+          " for the current version."
+        when :fail_passed_old
+          " for version #{last_pass_version}."
+        else
+          "."
+        end
     end
 
     def blame=(value)

--- a/public/style.css
+++ b/public/style.css
@@ -44,7 +44,8 @@
  * status marks
  * ----------------------------------------------------------------- */
 
-.pass, .fail, .tmpfail, .no_test_data {
+.pass, .fail, .tmpfail, .no_test_data, .fail_passed_never,
+.fail_passed_current, .fail_passed_old, .tmpfail_pass, .tmpfail_fail {
   font-family: 'FontAwesome';
 }
 
@@ -66,6 +67,31 @@
 .no_test_data:before {
   content: "\f06a ";
   color: #babdb6;
+}
+
+.fail_passed_never:before {
+  content: "\f165 \f05e ";
+  color: #ef2929;
+}
+
+.fail_passed_current:before {
+  content: "\f165 \f0e7 ";
+  color: #9e0000;
+}
+
+.fail_passed_old:before {
+  content: "\f165 \f063 ";
+  color: #c80c0c;
+}
+
+.tmpfail_pass:before {
+  content: "\f059 \f164 ";
+  color: #fffa62;
+}
+
+.tmpfail_fail:before {
+  content: "\f059 \f165 ";
+  color: #ffb062;
 }
 
 /* -----------------------------------------------------------------


### PR DESCRIPTION
This branch adds the concept of failure states, to distinguish between

 * tests which have never passed
 * tests which passed for a previous version, but never for the current version
 * tests which previously passed for the current version

This is implemented by adding `last_pass_version` and `last_pass_date` fields to the status JSON, avoiding the whole history needing to be scanned repeatedly to determine this property. This is read by the `Status` class which gains a new property `extended_status` which includes these extra states rather than just pass and fail.

This information is then added to headlines and css icons in several places. The UI side could probably be improved - at the moment it just adds an extra icon after the thumbs-down, and extends the status texts.